### PR TITLE
Fixes issue #12: Ability to change the url of imageupload in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Place settings in your `settings.py` to override default values:
 MARKDOWNX_MARKDOWN_EXTENSIONS = []
 MARKDOWNX_MARKDOWN_EXTENSION_CONFIGS = {}
 MARKDOWNX_URLS_PATH = '/markdownx/markdownify/' # Urls path that returns compiled markdown text. Change this path to your custom app url. That could i.e. enable do some additional work with compiled markdown text.
+MARKDOWNX_UPLOAD_URLS_PATH = '/markdownx/upload/' # Urls path for uploading image on text-editor. Will return markdown notation of the image. Change this path to your custom app url.
 MARKDOWNX_MEDIA_PATH = 'markdownx/' # subdirectory, where images will be stored in MEDIA_ROOT folder
 MARKDOWNX_UPLOAD_MAX_SIZE = 52428800 # 50MB
 MARKDOWNX_UPLOAD_CONTENT_TYPES = ['image/jpeg', 'image/png']

--- a/markdownx/settings.py
+++ b/markdownx/settings.py
@@ -7,6 +7,7 @@ MARKDOWNX_MARKDOWN_EXTENSION_CONFIGS = getattr(settings, 'MARKDOWNX_MARKDOWN_EXT
 
 # Markdown url
 MARKDOWNX_URLS_PATH = getattr(settings, 'MARKDOWNX_URLS_PATH', '/markdownx/markdownify/')
+MARKDOWNX_UPLOAD_URLS_PATH = getattr(settings, 'MARKDOWNX_UPLOAD_URLS_PATH', '/markdownx/upload/')
 
 # Media path
 MARKDOWNX_MEDIA_PATH = getattr(settings, 'MARKDOWNX_MEDIA_PATH', 'markdownx/')

--- a/markdownx/static/markdownx/js/markdownx.js
+++ b/markdownx/static/markdownx/js/markdownx.js
@@ -73,7 +73,7 @@
 
                 $.ajax({
                     type: 'POST',
-                    url: '/markdownx/upload/',
+                    url: markdownxEditor.data("markdownxUploadUrlsPath"),
                     data: form,
                     processData: false,
                     contentType: false,

--- a/markdownx/widgets.py
+++ b/markdownx/widgets.py
@@ -6,6 +6,7 @@ from django.contrib.admin import widgets
 from .settings import (
     MARKDOWNX_EDITOR_RESIZABLE,
     MARKDOWNX_URLS_PATH,
+    MARKDOWNX_UPLOAD_URLS_PATH,
 )
 
 
@@ -21,6 +22,7 @@ class MarkdownxWidget(forms.Textarea):
 
         attrs['data-markdownx-editor-resizable'] = MARKDOWNX_EDITOR_RESIZABLE
         attrs['data-markdownx-urls-path'] = MARKDOWNX_URLS_PATH
+        attrs['data-markdownx-upload-urls-path'] = MARKDOWNX_UPLOAD_URLS_PATH
 
         widget = super(MarkdownxWidget, self).render(name, value, attrs)
 


### PR DESCRIPTION
When writing, I noticed it might be cleaner to change the names of the settings to: MARKDOWNX_PREVIEW_URLS_PATH & MARKDOWNX_UPLOAD_URLS_PATH

But this would need a deprecation warning for older versions. I'm not sure what the policy is on that with the project.