### PR TITLE
Make rendering the markdown actually abstractable.

### DIFF
--- a/markdownx/views.py
+++ b/markdownx/views.py
@@ -1,13 +1,15 @@
-from django.views.generic.edit import View, FormView
+from django.conf import settings
 from django.http import HttpResponse, JsonResponse
+from django.utils.module_loading import import_string
+from django.views.generic.edit import View, FormView
 
 from .forms import ImageForm
-from .utils import markdownify
 
 
 class MarkdownifyView(View):
 
     def post(self, request, *args, **kwargs):
+        markdownify = import_string(settings.MARKDOWNX_MARKDOWNIFY_FUNCTION)
         return HttpResponse(markdownify(request.POST['content']))
 
 


### PR DESCRIPTION
Even after e35c1aa0c4b4f1c3e1d2122ead21e72c555d55f9, `MarkdownifyView`
is still hardcoded to call `markdownx.utils.mardownify`, regardless of
the value of `MARKDOWNX_MARKDOWNIFY_FUNCTION`. This commit calls the
function designated by that setting instead.