### PR TITLE
Make it possible to customize image insertion code.

### DIFF
--- a/markdownx/static/markdownx/js/markdownx.js
+++ b/markdownx/static/markdownx/js/markdownx.js
@@ -36,12 +36,11 @@
                 }
             };
 
-            var insertImage = function(image_path) {
+            var insertImage = function(textToInsert) {
                 var cursor_pos = markdownxEditor.prop('selectionStart');
                 var text = markdownxEditor.val();
                 var textBeforeCursor = text.substring(0, cursor_pos);
                 var textAfterCursor  = text.substring(cursor_pos, text.length);
-                var textToInsert = "![](" + image_path + ")";
 
                 markdownxEditor.val(textBeforeCursor + textToInsert + textAfterCursor);
                 markdownxEditor.prop('selectionStart', cursor_pos + textToInsert.length);
@@ -86,8 +85,8 @@
 
                     success: function(response) {
                         markdownxEditor.fadeTo("fast", 1);
-                        if (response.image_path) {
-                            insertImage(response.image_path);
+                        if (response.image_code) {
+                            insertImage(response.image_code);
                             console.log("success", response);
                         } else {
                             console.log('error: wrong response', response);

--- a/markdownx/static/markdownx/js/markdownx.js
+++ b/markdownx/static/markdownx/js/markdownx.js
@@ -88,6 +88,10 @@
                         if (response.image_code) {
                             insertImage(response.image_code);
                             console.log("success", response);
+                        } else if (response.image_path) {
+                            // For backwards-compatibility
+                            insertImage("![](" + image_path + ")");
+                            console.log("success", response);
                         } else {
                             console.log('error: wrong response', response);
                         }

--- a/markdownx/views.py
+++ b/markdownx/views.py
@@ -29,8 +29,7 @@ class ImageUploadView(FormView):
         response = super(ImageUploadView, self).form_valid(form)
 
         if self.request.is_ajax():
-            data = {}
-            data['image_path'] = image_path
-            return JsonResponse(data)
+            image_code = '![]({})'.format(image_path)
+            return JsonResponse({'image_code': image_code})
         else:
             return response


### PR DESCRIPTION
It can be useful to insert more that just a markdown image tag, for
example to provide additional control on the layout of images. Since
there's no convenient way to handle this on the JavaScript side, we
generate the code to insert in Python. Then it can be overridden with
the existing extensibility mechanism, that is, with a custom view.