### PR TITLE
Stop widget being overridden if set to a multiwidget containing a markdownx widget

### DIFF
--- a/markdownx/fields.py
+++ b/markdownx/fields.py
@@ -11,5 +11,11 @@ class MarkdownxFormField(forms.CharField):
     def __init__(self, *args, **kwargs):
         super(MarkdownxFormField, self).__init__(*args, **kwargs)
 
-        if not issubclass(self.widget.__class__, MarkdownxWidget):
+        if issubclass(self.widget.__class__, forms.widgets.MultiWidget):
+            if not any([
+                issubclass(x.__class__, MarkdownxWidget)
+                for x in self.widget.widgets
+            ]):
+                self.widget = MarkdownxWidget()
+        elif not issubclass(self.widget.__class__, MarkdownxWidget):
             self.widget = MarkdownxWidget()


### PR DESCRIPTION
Whilst trying to apply a multiwidget to a markdownxformfield I found it was being forcibly overridden.  This allows multiwidgets, with markdown widgets contained, through the check.