### PR TITLE
Add self.attrs to operate normally.

### DIFF
--- a/markdownx/widgets.py
+++ b/markdownx/widgets.py
@@ -12,6 +12,7 @@ from .settings import (
 class MarkdownxWidget(forms.Textarea):
 
     def render(self, name, value, attrs=None):
+        attrs.update(self.attrs)
         if attrs is None:
             attrs = {}
         elif 'class' in attrs:


### PR DESCRIPTION
I have a problem to develop using this package.

```python
class MyModelForm(forms.ModelForm):
  class Meta:
    model = MyModel
    field_classes = {'content': MarkdownxFormField,}
    widgets = {'content': MarkdowxWidget(attrs={'class':'form-control'})}
```

So I override your function 'render' and merge attrs and self.attrs and it works.
Also, I think it will handle this problem.