### PR TITLE
Only import PIL when calling scale_and_crop

### DIFF
--- a/markdownx/utils.py
+++ b/markdownx/utils.py
@@ -1,7 +1,5 @@
 import markdown
 
-from PIL import Image
-
 from .settings import MARKDOWNX_MARKDOWN_EXTENSIONS, MARKDOWNX_MARKDOWN_EXTENSION_CONFIGS
 
 
@@ -13,6 +11,8 @@ def markdownify(content):
     )
 
 def scale_and_crop(image, size, crop=False, upscale=False, quality=None):
+    from PIL import Image
+
     # Open image and store format/metadata.
     image.open()
     im = Image.open(image)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 Django
-Pillow
 Markdown


### PR DESCRIPTION
This PR makes Pillow an optional dependency.

Pillow is a very big dependency; we're not using image uploads, but we still use markdownx as a utility.